### PR TITLE
fix: allow static assets on vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,12 +5,11 @@
       "dest": "/api/$1"
     },
     {
+      "handle": "filesystem"
+    },
+    {
       "src": "/(.*)",
-      "dest": "/index.html",
-      "missing": [
-        { "type": "file" },
-        { "type": "route" }
-      ]
+      "dest": "/index.html"
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,11 @@
     },
     {
       "src": "/(.*)",
-      "dest": "/index.html"
+      "dest": "/index.html",
+      "missing": [
+        { "type": "file" },
+        { "type": "route" }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- avoid rewriting existing files when routing through Vercel so built assets are served correctly

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68d4b057777c83269f18fab8e821604b